### PR TITLE
Fix plugin validation issues and update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- project coordinates -->
     <groupId>io.github.orhankupusoglu</groupId>
     <artifactId>sloc-maven-plugin</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <!-- meta data -->
@@ -83,33 +83,40 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.8.1</version>
+            <version>3.9.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-component-annotations</artifactId>
-            <version>1.7.1</version>
+            <version>2.2.0</version>
             </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.5.4</version>
+            <version>3.9.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.5.2</version>
+            <version>3.11.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.1.0</version>
+            <version>3.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -119,7 +126,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.12.1</version>
                 <configuration>
                     <compilerArgument>-Xlint:all</compilerArgument>
                     <showWarnings>true</showWarnings>
@@ -129,12 +136,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.0</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-metadata</artifactId>
-                <version>2.1.1</version>
+                <version>2.2.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -146,7 +153,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <id>mojo-descriptor</id>
@@ -165,7 +172,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <addMavenDescriptor>false</addMavenDescriptor>
@@ -192,7 +199,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -206,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -237,7 +244,7 @@
                     <dependency>
                         <groupId>org.apache.httpcomponents</groupId>
                         <artifactId>httpcore</artifactId>
-                        <version>4.4.10</version>
+                        <version>4.4.16</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -254,7 +261,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.6.3</version>
                 <configuration>
                     <show>protected</show>
                     <nohelp>true</nohelp>
@@ -263,17 +270,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-docck-plugin</artifactId>
-                <version>1.1</version>
+                <version>1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.5</version>
+                <version>3.3.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.9</version>
+                <version>3.5.0</version>
                 <configuration>
                     <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
                 </configuration>


### PR DESCRIPTION
Neat plugin and very useful!! :)

This PR updates the plugin's POM in order to address two plugin validation issues and to update a number of outdated plugin and project dependencies.

Some dependencies of Maven plugins are expected to be in provided scope.

```
[WARNING] Plugin [INTERNAL, EXTERNAL] validation issues were detected in following plugin(s)
[WARNING] 
[WARNING]  * io.github.orhankupusoglu:sloc-maven-plugin:1.0.3
[WARNING]   Plugin EXTERNAL issue(s):
[WARNING]    * Plugin mixes multiple Maven versions: [3.8.1, 3.5.4]
[WARNING]    * Plugin should declare Maven artifacts in `provided` scope. If the plugin already declares them in `provided` scope, update the maven-plugin-plugin to latest version. Artifacts found with wrong scope: [org.apache.maven:maven-core:3.8.1, org.apache.maven:maven-plugin-api:3.5.4]
```
Plugin makes use of commons-lang3 but dependency was not declared (dependency was instead resolved transitively).
Dependency on org.apache.commons:commons-lang3:3.14.0 added.

Some outdated plugin dependencies have issues that are now resolved by version updates.

```
[WARNING] Plugin [INTERNAL, EXTERNAL] validation issues were detected in following plugin(s)
[WARNING] 
[WARNING]  * org.apache.maven.plugins:maven-javadoc-plugin:3.0.1
[WARNING]  * org.apache.maven.plugins:maven-compiler-plugin:3.7.0
[WARNING]  * org.apache.maven.plugins:maven-gpg-plugin:3.0.1
[WARNING]  * org.apache.maven.plugins:maven-plugin-plugin:3.5.2
[WARNING]  * org.codehaus.plexus:plexus-component-metadata:2.1.1
[WARNING]  * org.apache.maven.plugins:maven-source-plugin:3.0.1
```
Built and tested on one of my projects --> no more warnings on the output

`mvn io.github.orhankupusoglu:sloc-maven-plugin:1.0.4-SNAPSHOT:sloc -Dmaven.plugin.validation=VERBOSE`