### PR TITLE
Make plugin independent from Apache commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <!-- project coordinates -->
     <groupId>io.github.orhankupusoglu</groupId>
     <artifactId>sloc-maven-plugin</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <!-- meta data -->
@@ -107,11 +107,6 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>3.5.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/kupusoglu/orhan/sloc_maven_plugin/engine/Common.java
+++ b/src/main/java/kupusoglu/orhan/sloc_maven_plugin/engine/Common.java
@@ -1,6 +1,5 @@
 package kupusoglu.orhan.sloc_maven_plugin.engine;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
@@ -8,6 +7,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 
@@ -95,7 +95,7 @@ public class Common {
             String commonPackage = "";
 
             if (trimPkgNames) {
-                commonPackage = StringUtils.getCommonPrefix(packageNames);
+                commonPackage = getCommonPackagePrefix(packageNames);
 
                 // if all package names are identical, trim the last part of the common package name
                 if (commonPackage.length() == longestPName) {
@@ -170,4 +170,24 @@ public class Common {
 
         return sb;
     }
+
+    public static String getCommonPackagePrefix(String[] packages) {
+        if (packages == null || packages.length == 0) {
+            return null;
+        } else if (packages.length == 1) {
+            return packages[0];
+        }
+        List<String> list = Arrays.stream(packages).filter(Objects::nonNull).distinct().collect(Collectors.toList());
+        String firstPackage = list.remove(0);
+        for (int i = 0; i < firstPackage.length(); i++) {
+            char c = firstPackage.charAt(i);
+            for (String pack : list) {
+                if (i == pack.length() || pack.charAt(i) != c) {
+                    return firstPackage.substring(0, i);
+                }
+            }
+        }
+        return firstPackage;
+    }
+
 }

--- a/src/test/java/kupusoglu/orhan/sloc_maven_plugin/engine/CommonTest.java
+++ b/src/test/java/kupusoglu/orhan/sloc_maven_plugin/engine/CommonTest.java
@@ -72,6 +72,17 @@ public class CommonTest extends AbstractMojo {
         }
     }
 
+    @Test
+    public void getCommonPackagePrefix() {
+        Assert.assertNull(Common.getCommonPackagePrefix(null));
+        Assert.assertNull(Common.getCommonPackagePrefix(new String[0]));
+        Assert.assertEquals("", Common.getCommonPackagePrefix(new String[] {""}));
+        Assert.assertEquals("kupusoglu.orhan", Common.getCommonPackagePrefix(new String[] {"kupusoglu.orhan.a", "kupusoglu.orhan.b", "kupusoglu.orhan"}));
+        Assert.assertEquals("a.b", Common.getCommonPackagePrefix(new String[] {"a.b.c", "a.b", "a.b.c.d"}));
+        Assert.assertEquals("a.b", Common.getCommonPackagePrefix(new String[] {"a.b.c.d", "a.b.c", "a.b"}));
+        Assert.assertEquals("a.b", Common.getCommonPackagePrefix(new String[] {"a.b.c.d", "a.b.c", null, "a.b"}));
+    }
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         // not used


### PR DESCRIPTION
Introduce static method `Common.getCommonPackagePrefix(String[])` which determines the longest common prefix of an array of package names to avoids dependency on **Apache commons-lang3** completely.